### PR TITLE
Upgrade GolangCI-lint to v1.48.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -122,6 +122,6 @@ issues:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.45.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.48.x # use the fixed version to not introduce new linters unexpectedly
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"


### PR DESCRIPTION
There are a number of failures that come up with this version and I'm not sure about how to fix:

```
l2discovery.go:86:8: could not import C (cgo preprocessing failed) (typecheck)
import "C"
       ^
l2discovery.go:168:36: AF_PACKET not declared by package syscall (typecheck)
        fd, err := syscall.Socket(syscall.AF_PACKET, syscall.SOCK_RAW, syscall.ETH_P_ALL)
                                          ^
l2discovery.go:174:16: BindToDevice not declared by package syscall (typecheck)
        err = syscall.BindToDevice(fd, iface.IfName)
                      ^
l2discovery.go:194:19: SockaddrLinklayer not declared by package syscall (typecheck)
        var addr syscall.SockaddrLinklayer
                         ^
l2discovery.go:195:26: ETH_P_ARP not declared by package syscall (typecheck)
        addr.Protocol = syscall.ETH_P_ARP
                                ^
l2discovery.go:197:24: ARPHRD_ETHER not declared by package syscall (typecheck)
        addr.Hatype = syscall.ARPHRD_ETHER
                              ^
l2discovery.go:215:36: AF_PACKET not declared by package syscall (typecheck)
        fd, err := syscall.Socket(syscall.AF_PACKET, syscall.SOCK_RAW, allEthPacketTypes)
                                          ^
make: *** [lint] Error 1
```

Looks like there are a number of variables that are no longer declared by `syscall`.  See the documentation and they are not there: https://pkg.go.dev/syscall

Related to:
https://github.com/test-network-function/cnf-certification-test/pull/358