### PR TITLE
Upgrade GolangCI-lint v1.49.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,7 +51,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - depguard
     - dogsled
     - dupl
@@ -79,11 +78,9 @@ linters:
     - rowserrcheck
     - staticcheck
     - stylecheck
-    - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
     - whitespace
   # don't enable:
   # - asciicheck
@@ -99,6 +96,7 @@ linters:
   # - exportloopref
   # - structcheck
   # - testpackage
+  # - typecheck
   # - wsl
 issues:
   # Excluding configuration per-path, per-linter, per-text and per-source
@@ -122,6 +120,6 @@ issues:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.48.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.49.x # use the fixed version to not introduce new linters unexpectedly
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,18 @@
+GO_PACKAGES=$(shell go list ./... | grep -v vendor)
+
+# Get default value of $GOBIN if not explicitly set
+GO_PATH=$(shell go env GOPATH)
+ifeq (,$(shell go env GOBIN))
+  GOBIN=${GO_PATH}/bin
+else
+  GOBIN=$(shell go env GOBIN)
+endif
+
+# Variables
+GOLANGCI_VERSION=v1.49.0
+
 lint:
-	golangci-lint run
+	golangci-lint run --timeout 10m0s
 image:
 	./scripts/image.sh
 launch:
@@ -9,3 +22,5 @@ exe:
 # Install golangci-lint	
 install-lint:
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ${GO_PATH}/bin ${GOLANGCI_VERSION}
+vet:
+	go vet ${GO_PACKAGES}


### PR DESCRIPTION
https://github.com/golangci/golangci-lint/releases/tag/v1.49.0

Similar to:
- https://github.com/test-network-function/cnf-certification-test/pull/456
- https://github.com/test-network-function/cnfcert-tests-verification/pull/128