### PR TITLE
Update Go to 1.18.6

### DIFF
--- a/.github/workflows/build-latest-image.yml
+++ b/.github/workflows/build-latest-image.yml
@@ -51,10 +51,10 @@ jobs:
       KUBECONFIG: '/home/runner/.kube/config'
 
     steps:
-      - name: Set up Go 1.18.4
+      - name: Set up Go 1.18.6
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.4
+          go-version: 1.18.6
 
       - name: Disable default go problem matcher
         run: echo "::remove-matcher owner=go::"


### PR DESCRIPTION
https://groups.google.com/g/golang-announce/c/x49AQzIVX-s

Similar changes:
- https://github.com/test-network-function/cnfcert-tests-verification/pull/132
- https://github.com/test-network-function/test-network-function-claim/pull/62
- https://github.com/test-network-function/cnf-certification-test/pull/492
- https://github.com/test-network-function/privileged-daemonset/pull/7
- https://github.com/test-network-function/oct/pull/1