### PR TITLE
Update Go to v1.19.2

### DIFF
--- a/.github/workflows/build-latest-image.yml
+++ b/.github/workflows/build-latest-image.yml
@@ -51,10 +51,10 @@ jobs:
       KUBECONFIG: '/home/runner/.kube/config'
 
     steps:
-      - name: Set up Go 1.19.1
+      - name: Set up Go 1.19.2
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.1
+          go-version: 1.19.2
 
       - name: Disable default go problem matcher
         run: echo "::remove-matcher owner=go::"


### PR DESCRIPTION
https://groups.google.com/g/golang-announce/c/xtuG5faxtaU

Security: Includes security fixes for archive/tar (CVE-2022-2879), net/http (CVE-2022-2880), and regexp (CVE-2022-41715).

Related to: https://github.com/test-network-function/cnf-certification-test/pull/571