### PR TITLE
Upgrade GolangCI-lint to v1.50.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -120,6 +120,6 @@ issues:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.49.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.50.x # use the fixed version to not introduce new linters unexpectedly
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ else
 endif
 
 # Variables
-GOLANGCI_VERSION=v1.49.0
+GOLANGCI_VERSION=v1.50.0
 
 lint:
 	golangci-lint run --timeout 10m0s


### PR DESCRIPTION
https://github.com/golangci/golangci-lint/releases/tag/v1.50.0

Related to: https://github.com/test-network-function/cnf-certification-test/pull/604