### PR TITLE
Upgrade Go to v1.20.1

### DIFF
--- a/.github/workflows/build-latest-image.yml
+++ b/.github/workflows/build-latest-image.yml
@@ -51,10 +51,10 @@ jobs:
       KUBECONFIG: '/home/runner/.kube/config'
 
     steps:
-      - name: Set up Go 1.19.6
+      - name: Set up Go 1.20.1
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.6
+          go-version: 1.20.1
 
       - name: Disable default go problem matcher
         run: echo "::remove-matcher owner=go::"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/test-network-function/l2discovery
 
-go 1.19
+go 1.20
 
 require github.com/sirupsen/logrus v1.9.0
 


### PR DESCRIPTION
Release Notes: https://tip.golang.org/doc/go1.20

Related to: https://github.com/test-network-function/cnf-certification-test/pull/873