### PR TITLE
tight loop prevention in case of repeated failure

### DIFF
--- a/l2discovery.go
+++ b/l2discovery.go
@@ -283,8 +283,8 @@ func PrintLog() {
 
 func sendProbeForever(iface *exports.Iface) {
 	for {
-		sendProbe(iface)
 		time.Sleep(time.Second * 1)
+		sendProbe(iface)
 	}
 }
 


### PR DESCRIPTION
suspected tight loop happening when security context are not configured to allow capabilities requested by syscalls. Instead of waiting after the call succeeds, now waiting before. This way the wait call always succeeds even in case of failure in the syscall, thus preventing the tightloop