### PR TITLE
Fix linkagg

### DIFF
--- a/l2discovery.go
+++ b/l2discovery.go
@@ -282,7 +282,10 @@ func PrintLog() {
 }
 
 func sendProbeForever(iface *exports.Iface) {
-	for {
+	// sending probe frames mess with link aggregation. After sending a maximum number of probes for a given
+	// interface, stop forever. Discovery should be complete by then.
+	const maxProbes = 5
+	for i := 0; i < maxProbes; i++ {
 		time.Sleep(time.Second * 1)
 		sendProbe(iface)
 	}


### PR DESCRIPTION
Adding a limit with the number of probe frames sent to avoid issues created by broadcast frames, for instance for link aggregation