### PR TITLE
Link aggregation limited support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.20
 require github.com/sirupsen/logrus v1.9.0
 
 require (
-	github.com/test-network-function/l2discovery-exports v0.0.2
+	github.com/test-network-function/l2discovery-exports v0.0.3
 	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/test-network-function/l2discovery-exports v0.0.2 h1:votJhdo+/Wc/oUY+i0IvonDOSK3CcM92zNNyhopTikY=
 github.com/test-network-function/l2discovery-exports v0.0.2/go.mod h1:38JgpFHXB9PQ+4bPZQ+STsUKK9BrTe+5uDq47OeMV50=
+github.com/test-network-function/l2discovery-exports v0.0.3 h1:kuzpWu5UQL3VIG+8AkjmsghkjZN1X3k3dQ8M36DsJc4=
+github.com/test-network-function/l2discovery-exports v0.0.3/go.mod h1:38JgpFHXB9PQ+4bPZQ+STsUKK9BrTe+5uDq47OeMV50=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
**Background on link aggregation:** 
Link aggregation aggregates multiple slave links to realize a virtual aggregated interface with better throughput and/or reliability. One slave link is elected to carry multicast and broadcast traffic while the unicast traffic conversations is load balanced across the other slave links. The reason for this is sending broadcast across all links will create loops in certain scenarios (e.g. when 2 or more switches support the slave links).
Current l2 discovery implementation sends frames on every slave link in a lag group which creates loops in certain scenarios.  
**Adds support for probing link aggregated links:** 
- lag virtual interfaces are skipped as before 
- lag slave interfaces are not used to send probe frames. Instead their master interface (the lag virtual interface) is used to send the broadcast probe, thus using the reserved broadcast channel as defined by the link aggregation protocol.
- probe frames are listened to as usual on the lag slave links
- as supported by lag, only one slave link will be transmitting and receiving the broadcast probe, so only this link will be discovered by l2discovery 