### PR TITLE
Update Go to v1.21.0

### DIFF
--- a/.github/workflows/build-latest-image.yml
+++ b/.github/workflows/build-latest-image.yml
@@ -51,10 +51,10 @@ jobs:
       KUBECONFIG: '/home/runner/.kube/config'
 
     steps:
-      - name: Set up Go 1.20.7
+      - name: Set up Go 1.21.0
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.7
+          go-version: 1.21.0
 
       - name: Disable default go problem matcher
         run: echo "::remove-matcher owner=go::"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/test-network-function/l2discovery
 
-go 1.20
+go 1.21
 
 require github.com/sirupsen/logrus v1.9.3
 


### PR DESCRIPTION
https://go.dev/doc/go1.21

Related to: https://github.com/test-network-function/cnf-certification-test/pull/1344